### PR TITLE
Potential alternative approach to MinGW compatibility

### DIFF
--- a/LEGO1/compat.h
+++ b/LEGO1/compat.h
@@ -1,7 +1,7 @@
 #ifndef ISLECOMPAT_H
 #define ISLECOMPAT_H
 
-// Various defines to enable compiling on other platforms.
+// Various macros to enable compiling with other/newer compilers.
 
 // Use `COMPAT_CONST` where something ought to be 'const', and a newer compiler would complain if it
 // wasn't, but we know it isn't 'const' in the original code.

--- a/LEGO1/compat.h
+++ b/LEGO1/compat.h
@@ -1,0 +1,14 @@
+#ifndef ISLECOMPAT_H
+#define ISLECOMPAT_H
+
+// Various defines to enable compiling on other platforms.
+
+// Use `COMPAT_CONST` where something ought to be 'const', and a newer compiler would complain if it
+// wasn't, but we know it isn't 'const' in the original code.
+#ifdef __MINGW32__
+#define COMPAT_CONST const
+#else
+#define COMPAT_CONST
+#endif
+
+#endif // ISLECOMPAT_H

--- a/LEGO1/legoomni.cpp
+++ b/LEGO1/legoomni.cpp
@@ -106,18 +106,11 @@ void LegoOmni::Init()
 }
 
 // OFFSET: LEGO1 0x10058e70
-MxResult LegoOmni::Create(MxOmniCreateParam &p)
+MxResult LegoOmni::Create(COMPAT_CONST MxOmniCreateParam &p)
 {
   // FIXME: Stub
   return SUCCESS;
 }
-
-#if defined(__MINGW32__)
-MxResult LegoOmni::Create(const MxOmniCreateParam &p)
-{
-  return Create((MxOmniCreateParam &)p);
-}
-#endif
 
 void LegoOmni::Destroy()
 {

--- a/LEGO1/legoomni.h
+++ b/LEGO1/legoomni.h
@@ -1,6 +1,7 @@
 #ifndef LEGOOMNI_H
 #define LEGOOMNI_H
 
+#include "compat.h"
 #include "legoentity.h"
 #include "legoinputmanager.h"
 #include "legogamestate.h"
@@ -50,7 +51,7 @@ public:
   }
 
   virtual void Init(); // vtable+14
-  virtual MxResult Create(MxOmniCreateParam &p); // vtable+18
+  virtual MxResult Create(COMPAT_CONST MxOmniCreateParam &p); // vtable+18
   virtual void Destroy(); // vtable+1c
   virtual void vtable20();
   virtual void vtable24(MxDSAction &ds);
@@ -61,10 +62,6 @@ public:
   virtual void vtable38();
   virtual void vtable3c();
   virtual unsigned char vtable40();
-
-#if defined(__MINGW32__)
-  virtual MxResult Create(const MxOmniCreateParam &p); // vtable+18
-#endif
 
   LegoVideoManager *GetVideoManager() { return (LegoVideoManager *) m_videoManager; }
   LegoSoundManager *GetSoundManager() { return (LegoSoundManager *)m_soundManager;}

--- a/LEGO1/mxvideoparam.cpp
+++ b/LEGO1/mxvideoparam.cpp
@@ -17,7 +17,7 @@ MxVideoParam::MxVideoParam()
 }
 
 // OFFSET: LEGO1 0x100beca0
-MxVideoParam::MxVideoParam(MxRect32 &p_rect, MxPalette *p_pal, unsigned long p_backBuffers, MxVideoParamFlags &p_flags)
+MxVideoParam::MxVideoParam(COMPAT_CONST MxRect32 &p_rect, MxPalette *p_pal, unsigned long p_backBuffers, COMPAT_CONST MxVideoParamFlags &p_flags)
 {
   this->m_rect.m_left = p_rect.m_left;
   this->m_rect.m_top = p_rect.m_top;

--- a/LEGO1/mxvideoparam.h
+++ b/LEGO1/mxvideoparam.h
@@ -3,6 +3,7 @@
 
 #include <ddraw.h>
 
+#include "compat.h"
 #include "mxpalette.h"
 #include "mxrect32.h"
 #include "mxtypes.h"
@@ -14,16 +15,9 @@ class MxVideoParam
 public:
   __declspec(dllexport) MxVideoParam();
   __declspec(dllexport) MxVideoParam(MxVideoParam &);
-  __declspec(dllexport) MxVideoParam(MxRect32 &rect, MxPalette *pal, unsigned long p3, MxVideoParamFlags &flags);
+  __declspec(dllexport) MxVideoParam(COMPAT_CONST MxRect32 &rect, MxPalette *pal, unsigned long p3, COMPAT_CONST MxVideoParamFlags &flags);
   __declspec(dllexport) MxVideoParam &operator=(const MxVideoParam &);
   __declspec(dllexport) ~MxVideoParam();
-
-#ifdef __MINGW32__
-  __declspec(dllexport) MxVideoParam(const MxRect32 &rect, MxPalette *pal, unsigned long p3, const MxVideoParamFlags &flags)
-  : MxVideoParam((MxRect32 &)rect, pal, p3, (MxVideoParamFlags &)flags)
-  {
-  }
-#endif
 
   __declspec(dllexport) void SetDeviceName(char *id);
 


### PR DESCRIPTION
The reason I prefer this approach is because it cuts down on the amount of `ifdef`s, and contains them to a separate header unlikely to interfere with the code being decompiled (and makes very minor modifications to the decompiled code too). Let me know what you think.