### PR TITLE
Config tweaks and MxDirect3d annotations

### DIFF
--- a/CONFIG/MainDlg.cpp
+++ b/CONFIG/MainDlg.cpp
@@ -314,18 +314,16 @@ void CMainDialog::SwitchToAdvanced(BOOL p_advanced)
 	CWnd* button_advanced = GetDlgItem(IDC_BTN_ADVANCED);
 	m_advanced = p_advanced;
 	int height;
-	const char* new_text;
 	if (p_advanced) {
 		height = grp_advanced_rect.bottom - dialog_rect.top + 10;
 		GetDlgItem(IDC_BMP_SHARK)->EnableWindow(TRUE);
-		new_text = "Basic";
+		button_advanced->SetWindowText("Basic");
 	}
 	else {
 		height = grp_advanced_rect.top - dialog_rect.top;
 		GetDlgItem(IDC_BMP_SHARK)->EnableWindow(FALSE);
-		new_text = "Advanced";
+		button_advanced->SetWindowText("Advanced");
 	}
-	button_advanced->SetWindowText(new_text);
 	SetWindowPos(&wndTop, 0, 0, dialog_rect.right - dialog_rect.left, height, SWP_NOMOVE);
 }
 

--- a/CONFIG/config.h
+++ b/CONFIG/config.h
@@ -24,9 +24,6 @@ public:
 	//{{AFX_VIRTUAL(CConfigApp)
 
 public:
-	void Serialize(CArchive& ar) override {}
-	void AssertValid() const override {}
-	void Dump(CDumpContext& dc) const override {}
 	BOOL InitInstance() override;
 	int ExitInstance() override;
 	//}}AFX_VIRTUAL

--- a/CONFIG/library_mfc.h
+++ b/CONFIG/library_mfc.h
@@ -1,0 +1,12 @@
+#ifdef 0
+
+// FUNCTION: CONFIG 0x402ca0
+// CObject::Serialize
+
+// FUNCTION: CONFIG 0x402cb0
+// CObject::AssertValid
+
+// FUNCTION: CONFIG 0x402cc0
+// CObject::Dump
+
+#endif

--- a/LEGO1/mxdirectx/mxdirect3d.cpp
+++ b/LEGO1/mxdirectx/mxdirect3d.cpp
@@ -349,6 +349,7 @@ MxDriver::MxDriver(LPGUID p_guid, LPSTR p_driverDesc, LPSTR p_driverName)
 	Init(p_guid, p_driverDesc, p_driverName);
 }
 
+// FUNCTION: CONFIG 0x401280
 // FUNCTION: LEGO1 0x1009bb80
 MxDriver::~MxDriver()
 {
@@ -407,6 +408,7 @@ MxDevice::MxDevice(
 	Init(p_guid, p_deviceDesc, p_deviceName, p_HWDesc, p_HELDesc);
 }
 
+// FUNCTION: CONFIG 0x401460
 // FUNCTION: LEGO1 0x1009bd60
 MxDevice::~MxDevice()
 {
@@ -469,6 +471,12 @@ void MxDevice::Init(
 MxDeviceEnumerate::MxDeviceEnumerate()
 {
 	m_initialized = FALSE;
+}
+
+// FUNCTION: CONFIG 0x401710
+// FUNCTION: LEGO1 0x1009c010
+MxDeviceEnumerate::~MxDeviceEnumerate()
+{
 }
 
 // FUNCTION: CONFIG 0x00401770

--- a/LEGO1/mxdirectx/mxdirect3d.h
+++ b/LEGO1/mxdirectx/mxdirect3d.h
@@ -139,36 +139,45 @@ struct MxDriver {
 };
 
 // clang-format off
+// TEMPLATE: CONFIG 0x401000
 // TEMPLATE: LEGO1 0x1009b900
 // list<MxDevice,allocator<MxDevice> >::~list<MxDevice,allocator<MxDevice> >
 // clang-format on
 
 // clang-format off
+// TEMPLATE: CONFIG 0x401070
 // TEMPLATE: LEGO1 0x1009b970
 // list<MxDisplayMode,allocator<MxDisplayMode> >::~list<MxDisplayMode,allocator<MxDisplayMode> >
 // clang-format on
 
+// TEMPLATE: CONFIG 0x4010e0
 // TEMPLATE: LEGO1 0x1009b9e0
 // List<MxDevice>::~List<MxDevice>
 
+// TEMPLATE: CONFIG 0x401130
 // TEMPLATE: LEGO1 0x1009ba30
 // List<MxDisplayMode>::~List<MxDisplayMode>
 
 // clang-format off
+// TEMPLATE: CONFIG 0x401650
 // TEMPLATE: LEGO1 0x1009bf50
 // list<MxDriver,allocator<MxDriver> >::~list<MxDriver,allocator<MxDriver> >
 // clang-format on
 
+// TEMPLATE: CONFIG 0x4016c0
 // TEMPLATE: LEGO1 0x1009bfc0
 // List<MxDriver>::~List<MxDriver>
 
 // Compiler-generated copy ctor
+// SYNTHETIC: CONFIG 0x401990
 // SYNTHETIC: LEGO1 0x1009c290
 // MxDriver::MxDriver
 
+// SYNTHETIC: CONFIG 0x401b00
 // SYNTHETIC: LEGO1 0x1009c400
 // list<MxDevice,allocator<MxDevice> >::insert
 
+// SYNTHETIC: CONFIG 0x401b60
 // SYNTHETIC: LEGO1 0x1009c460
 // list<MxDisplayMode,allocator<MxDisplayMode> >::insert
 
@@ -184,9 +193,7 @@ struct MxDriver {
 class MxDeviceEnumerate {
 public:
 	MxDeviceEnumerate();
-	// FUNCTION: CONFIG 0x00401650
-	// FUNCTION: LEGO1 0x1009c010
-	~MxDeviceEnumerate() {}
+	~MxDeviceEnumerate();
 
 	virtual int DoEnumerate(); // vtable+0x00
 


### PR DESCRIPTION
Added some missing `CONFIG` annotations to `MxDirect3d`.

Removed the three overridden functions from `CConfigApp` so they use the `CObject` versions, and that matches what I see in ghidra. That leaves only the `BeginModalState` / `EndModalState` issue to fix for the vtables.

I got `CMainDialog::SwitchToAdvanced` to match a little better so that's here too.

The big thing that will help the match percentage is using the `operator new` and `operator delete` functions from the MFC dll instead of the built-in MSVC ones. Those are the symbols `??2@YAPAXI@Z` and `??3@YAXPAX@Z`.